### PR TITLE
转换ERNIE时，Layernorm的权重按照主流的方式命名，避免采坑

### DIFF
--- a/convert_ernie_to_pytorch.py
+++ b/convert_ernie_to_pytorch.py
@@ -28,8 +28,8 @@ def build_weight_map():
         'word_embedding': 'bert.embeddings.word_embeddings.weight',
         'pos_embedding': 'bert.embeddings.position_embeddings.weight',
         'sent_embedding': 'bert.embeddings.token_type_embeddings.weight',
-        'pre_encoder_layer_norm_scale': 'bert.embeddings.LayerNorm.gamma',
-        'pre_encoder_layer_norm_bias': 'bert.embeddings.LayerNorm.beta',
+        'pre_encoder_layer_norm_scale': 'bert.embeddings.LayerNorm.weight',
+        'pre_encoder_layer_norm_bias': 'bert.embeddings.LayerNorm.bias',
     })
 
     def add_w_and_b(ernie_pre, pytroch_pre):


### PR DESCRIPTION
有的包(namisan/mt-dnn)默认在加载pytorch-pretrained-BERT的模型时
会默认Layernorm权重命名风格都是以weight/bias命名
所以为了避免采坑，建议直接把ERNIE的权重的gamma/beta都命名为weight/bias